### PR TITLE
Fix Event.verify() method

### DIFF
--- a/src/electrum_aionostr/event.py
+++ b/src/electrum_aionostr/event.py
@@ -113,8 +113,10 @@ class Event:
         self.sig = sig.hex()
 
     def verify(self) -> bool:
+        if not self.sig:
+            return False
         try:
-            pub_key = ECPubkey(bytes.fromhex(self.pubkey))
+            pub_key = ECPubkey(bytes.fromhex("02" + self.pubkey))
         except Exception as e:
             return False
         event_id = Event.compute_id(
@@ -132,7 +134,7 @@ class Event:
                 to_sign = (
                     ":".join(["nostr", "delegation", self.pubkey, conditions])
                 ).encode("utf8")
-                delegation_verified = PublicKey(bytes.fromhex(delegator)).verify(
+                delegation_verified = ECPubkey(bytes.fromhex("02" + delegator)).schnorr_verify(
                     bytes.fromhex(sig),
                     sha256(to_sign).digest(),
                 )

--- a/src/electrum_aionostr/event.py
+++ b/src/electrum_aionostr/event.py
@@ -54,7 +54,7 @@ class Event:
     ) -> None:
         if not isinstance(content, str):
             raise TypeError("Argument 'content' must be of type str")
-
+        assert len(pubkey) == 64, f"got pubkey with unexpected len={len(pubkey)}, expected 64 char x-only hex"
         self.pubkey = pubkey
         self.content = content
         self.created_at = created_at or int(time.time())

--- a/src/electrum_aionostr/relay.py
+++ b/src/electrum_aionostr/relay.py
@@ -261,6 +261,9 @@ class Manager:
                 if only_stored:
                     break
             else:
+                if not event.verify():
+                    self.log.debug(f"event {event.id} failed signature verification")
+                    continue
                 yield event
                 if single_event:
                     break

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,0 +1,24 @@
+import unittest
+from os import getrandom
+
+from electrum_aionostr.event import Event
+from electrum_aionostr.key import PrivateKey
+
+class TestEvent(unittest.TestCase):
+
+    def test_verify(self):
+        privkey1 = PrivateKey(getrandom(32))
+        privkey2 = PrivateKey(getrandom(32))
+
+        event = Event(
+            pubkey=privkey1.public_key.hex(),
+            content="test"
+        )
+        # verify event without signature
+        self.assertFalse(event.verify())
+        # verify event with correct signature
+        event.sign(privkey1.hex())
+        self.assertTrue(event.verify())
+        # verify event with incorrect signature
+        event.sign(privkey2.hex())
+        self.assertFalse(event.verify())


### PR DESCRIPTION
The `verify()` method to verify Events always failed because ECPubkey classes can only be constructed from a 33-byte pubkey, but nostr uses 32 byte pubkeys. According to NIP-01 nostr pubkeys always have a even y coordinate so i added the `02` prefix it here.