### PR TITLE
Add proxy support and replace websockets library with aiohttp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ license = {'file'="LICENSE"}
 requires-python = ">=3.8"
 dependencies = [
     "electrum_ecc",
-    "websockets",
+    "aiohttp>=3.3.0,<4.0.0",
+    "aiohttp_socks>=0.8.4",
     "cryptography>=2.8",
     "aiorpcx>=0.22.0,<0.25",  # for taskgroup. remove when we use python 3.11
 ]


### PR DESCRIPTION
The aiohttp library has (client) websocket support with proxies and is also used in electrum client. So I replaced the websockets library with it.
This works as-is with the current electrum master, a PR to pass the proxy to the aionostr will follow in the electrum repo.