### PR TITLE
manager: use actual passed connect timeout as timeout for connections

### DIFF
--- a/src/electrum_aionostr/relay.py
+++ b/src/electrum_aionostr/relay.py
@@ -257,9 +257,8 @@ class Manager:
     async def broadcast(self, relays, func, *args, **kwargs):
         """ returns when all tasks completed. timeout is enforced """
         results = []
-        timeout = self._connect_timeout + 2
         for relay in relays:
-            coro = asyncio.wait_for(getattr(relay, func)(*args, **kwargs), timeout=timeout)
+            coro = asyncio.wait_for(getattr(relay, func)(*args, **kwargs), timeout=self._connect_timeout)
             results.append(await self.taskgroup.spawn(coro))
 
         if not results:


### PR DESCRIPTION
Stops adding a +2 second buffer to the broadcast timeout as this makes the duration of a broadcast call longer than expected by consumers of the library without providing significant benefit.
Related to https://github.com/spesmilo/electrum/pull/9716