### PR TITLE
pyproject.toml: migrate to newer style "license" declaration

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 
 
-BSD License
+BSD-3-Clause License
 
 Copyright (c) 2023, Dave St.Germain
 Copyright (c) 2024-2025 The Electrum developers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ authors = [
 description = "asyncio nostr client"
 keywords = ["nostr", "asyncio"]
 readme = "README.md"
-license = {'file'="LICENSE"}
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
     "electrum_ecc",
@@ -21,7 +22,6 @@ dependencies = [
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: BSD License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Migrates from pep-621 style to pep-639 style.

Setuptools was spitting out warnings without this. (however I imagine this change might be breaking builds with old setuptools...)

ref https://github.com/spesmilo/electrum-ecc/pull/10