### PR TITLE
dependencies: make aes crypto optional

### DIFF
--- a/src/electrum_aionostr/key.py
+++ b/src/electrum_aionostr/key.py
@@ -7,10 +7,15 @@ from hashlib import sha256
 
 import electrum_ecc as ecc
 
-from .crypto_aes import aes_encrypt_with_iv, aes_decrypt_with_iv
 from .delegation import Delegation
-from .event import Event
 from . import bech32
+
+AES_AVAILABLE = False
+try:
+    from .crypto_aes import aes_encrypt_with_iv, aes_decrypt_with_iv
+    AES_AVAILABLE = True
+except ImportError:
+    pass
 
 
 class PublicKey:
@@ -70,6 +75,8 @@ class PrivateKey:
         return int.to_bytes(pt.x(), length=32, byteorder='big', signed=False)
 
     def encrypt_message(self, message: str, public_key_hex: str) -> str:
+        if not AES_AVAILABLE:
+            raise CryptoBackendUnavailableError
         iv = secrets.token_bytes(16)
         encrypted_message = aes_encrypt_with_iv(
             key=self.compute_shared_secret(public_key_hex),
@@ -79,6 +86,8 @@ class PrivateKey:
         return f"{base64.b64encode(encrypted_message).decode()}?iv={base64.b64encode(iv).decode()}"
 
     def decrypt_message(self, encoded_message: str, public_key_hex: str) -> str:
+        if not AES_AVAILABLE:
+            raise CryptoBackendUnavailableError
         encoded_data = encoded_message.split("?iv=")
         encoded_content, encoded_iv = encoded_data[0], encoded_data[1]
 
@@ -121,3 +130,11 @@ def mine_vanity_key(prefix: str = None, suffix: str = None) -> PrivateKey:
         break
 
     return sk
+
+
+class CryptoBackendUnavailableError(ImportError):
+    def __init__(self):
+        super().__init__(
+            "Error: at least one of ('pycryptodomex', 'cryptography') needs to be installed for NIP-04 functionality.\n"
+            "Install electrum-aionostr with with [crypto] feature: `pip install electrum-aionostr[crypto]`."
+        )

--- a/tests/test_key.py
+++ b/tests/test_key.py
@@ -1,7 +1,8 @@
 from hashlib import sha256
 import unittest
+from unittest.mock import patch
 
-from electrum_aionostr.key import PrivateKey, PublicKey
+from electrum_aionostr.key import PrivateKey, PublicKey, CryptoBackendUnavailableError
 
 
 bfh = bytes.fromhex
@@ -50,3 +51,13 @@ class TestKey(unittest.TestCase):
         ciphertext = privkey1.encrypt_message(msg1, privkey2.public_key.hex())
         self.assertEqual(msg1, privkey2.decrypt_message(ciphertext, privkey1.public_key.hex()))
         self.assertEqual(msg1, privkey1.decrypt_message(ciphertext, privkey2.public_key.hex()))
+
+    def test_crypto_backend_unavailable(self):
+        with patch('electrum_aionostr.key.AES_AVAILABLE', False):
+            key = PrivateKey()
+            random_pubkey = PrivateKey().public_key
+            key.compute_shared_secret(random_pubkey.hex())  # test some other functionality, shouldn't raise
+            with self.assertRaises(CryptoBackendUnavailableError):
+                key.encrypt_message(message="test", public_key_hex=random_pubkey.hex())
+            with self.assertRaises(CryptoBackendUnavailableError):
+                key.decrypt_message(encoded_message="test", public_key_hex=random_pubkey.hex())


### PR DESCRIPTION
Don't fail with import error if AES crypto isn't available, instead only fail if the user actually tries to use it for NIP-04. This allows use of aionostr for nostr stuff that doesn't need NIP-04 without having to pull in an unused dependency.

```
Traceback (most recent call last):
  File "/tmp/tes/main.py", line 5, in <module>
    x.encrypt_message("test", "test")
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/home/user/code/electrum-aionostr-fork/src/electrum_aionostr/key.py", line 79, in encrypt_message
    raise CryptoBackendUnavailableError
electrum_aionostr.key.CryptoBackendUnavailableError: Error: at least one of ('pycryptodomex', 'cryptography') needs to be installed for NIP-04 functionality.
Install electrum-aionostr with with [crypto] feature: `pip install electrum-aionostr[crypto]`.
```